### PR TITLE
BUGFIX: return repo name, not full repo URL

### DIFF
--- a/learn_duplicate.gemspec
+++ b/learn_duplicate.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'learn_duplicate'
-  s.version = '0.0.14'
+  s.version = '0.0.15'
   s.date = '2019-04-23'
   s.authors = ['flatironschool']
   s.email = 'maxwell@flatironschool.com'

--- a/lib/learn_duplicate.rb
+++ b/lib/learn_duplicate.rb
@@ -8,21 +8,21 @@ class LearnDuplicate
   def initialize(opts={})
     # For non-interactive mode
     if opts[:ni]
-      validate_repo = ->(url) do
+      validate_repo = ->(repo_name) do
+        url = GITHUB_ORG + repo_name
         encoded_url = URI.encode(url).slice(0, url.length)
         check_existing = Faraday.get URI.parse(encoded_url)
         if check_existing.body.include? '"Not Found"'
           raise IOError, "Could not connect to #{url}"
         end
-        url
+        repo_name
       end
 
       de_apiify_url = ->(api_url) do
         api_url.gsub(/(api\.|repos\/)/, '')
       end
 
-      validate_repo.call(GITHUB_ORG + opts[:source_name])
-      @old_repo = opts[:source_name]
+      @old_repo = validate_repo.call(opts[:source_name])
 
       if opts[:destination].length >= 100
         raise ArgumentError, 'Repository names must be shorter than 100 characters'


### PR DESCRIPTION
Was embedding an "https://..." inside an
"https://...#{str}"